### PR TITLE
Add intruccions on how to deploy with gunicorn and nginx

### DIFF
--- a/docs/nginx-deployment.md
+++ b/docs/nginx-deployment.md
@@ -22,7 +22,7 @@ WantedBy=multi-user.target
 
 - Start the service: `sudo systemctl start covfee`
 - Install nginx: `sudo apt install nginx`
-- Add a nginx config file for covfee in `/etc/nginx/sites-available/covfee`
+- Add an nginx config file for covfee in `/etc/nginx/sites-available/covfee`
 
 ```
 server {
@@ -44,7 +44,7 @@ server{
         index index.nginx-debian.html;
     }
 
-    # Show the the app at www.your_domain/covfee
+    # Show the app at www.your_domain/covfee
     location /covfee {
         rewrite ^/covfee/(.*)$ /$1 break; # Remove the /covfee from the URL before passing it to the proxy_pass below
         include proxy_params; # Add the proxy configuration from the proxy_params file from the parent folder

--- a/docs/nginx-deployment.md
+++ b/docs/nginx-deployment.md
@@ -1,0 +1,60 @@
+# How to deploy covfee using gunicorn and nginx.
+
+- Install conda / venv or any other environment manager and create a new environment for covfee
+- Install all the dependencies including gunicorn: `pip install gunicorn`
+- Create a systemd service to start the app with several workers and fault tolerance at `/etc/systemd/system/covfee.service`
+
+```toml
+[Unit]
+Description=Gunicorn instance to serve covfee
+After=network.target
+
+[Service]
+User=<YOUR USER>
+Group=www-data
+WorkingDirectory=/home/<YOUR USER>/covfee
+Environment="PATH=/home/<YOUR USER>/miniconda3/envs/covfee_env/bin"
+ExecStart=/home/<YOUR USER>/miniconda3/envs/covfee_env/bin/gunicorn --workers 3 --bind unix:covfee.sock -m 007 launch:create_app()
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- Start the service: `sudo systemctl start covfee`
+- Install nginx: `sudo apt install nginx`
+- Add a nginx config file for covfee in `/etc/nginx/sites-available/covfee`
+
+```toml
+server {
+    listen 80;
+    server_name your_domain www.your_domain;
+
+	# Redirect all connections to the https version of the site
+    return 301 https://your_domain$request_uri;
+}
+
+server{
+    listen 443 ssl;
+    ssl_certificate <your certificate>.pem;
+    ssl_certificate_key <your key>.key;
+
+    # Show the default nginx website at www.your_domain
+    location / {
+        root /var/www/html;
+        index index.nginx-debian.html;
+    }
+
+    # Show the the app at www.your_domain/covfee
+    location /covfee {
+        rewrite ^/covfee/(.*)$ /$1 break; # Remove the /covfee from the URL before passing it to the proxy_pass below
+        include proxy_params; # Add the proxy configuration from the proxy_params file from the parent folder
+        proxy_pass http://unix:/home/<YOUR USER>/covfee/covfee.sock; # Connect to the socket that was created by gunicorn
+    }
+}
+```
+
+- Activate the website `sudo ln -s /etc/nginx/sites-available/covfee /etc/nginx/sites-enabled`
+- Reload nginx: `sudo systemctl restart nginx`
+- Check that everything works at `your_domain/covfee`
+
+More information can be found in [this tutorial](https://www.digitalocean.com/community/tutorials/how-to-serve-flask-applications-with-gunicorn-and-nginx-on-ubuntu-18-04).

--- a/docs/nginx-deployment.md
+++ b/docs/nginx-deployment.md
@@ -4,7 +4,7 @@
 - Install all the dependencies including gunicorn: `pip install gunicorn`
 - Create a systemd service to start the app with several workers and fault tolerance at `/etc/systemd/system/covfee.service`
 
-```toml
+```
 [Unit]
 Description=Gunicorn instance to serve covfee
 After=network.target
@@ -24,7 +24,7 @@ WantedBy=multi-user.target
 - Install nginx: `sudo apt install nginx`
 - Add a nginx config file for covfee in `/etc/nginx/sites-available/covfee`
 
-```toml
+```
 server {
     listen 80;
     server_name your_domain www.your_domain;


### PR DESCRIPTION
Apache was giving me a lot of grief, so I ended up deploying with gunicorn and nginx. I'm leaving this here for future reference as it is not ready to be merged. You can see the readme at https://github.com/Era-Dorta-TU-Delft/covfee/blob/server-deployment/docs/nginx-deployment.md A test flask application is available at https://covfee.ewi.tudelft.nl/app1/ and you can find all the relevant files in the covfee server.